### PR TITLE
Add conversion queue feature

### DIFF
--- a/app/src/main/java/com/neaniesoft/sonicswitcher/data/ConvertedFile.kt
+++ b/app/src/main/java/com/neaniesoft/sonicswitcher/data/ConvertedFile.kt
@@ -1,0 +1,24 @@
+package com.neaniesoft.sonicswitcher.data
+
+import android.net.Uri
+
+/**
+ * Domain model for a converted file in the queue.
+ */
+data class ConvertedFile(
+    val id: Long,
+    val uri: Uri,
+    val displayName: String,
+    val timestampMillis: Long,
+)
+
+/**
+ * Converts entity to domain model.
+ */
+fun ConvertedFileEntity.toDomainModel() =
+    ConvertedFile(
+        id = id,
+        uri = Uri.parse(uri),
+        displayName = displayName,
+        timestampMillis = timestampMillis,
+    )

--- a/app/src/main/java/com/neaniesoft/sonicswitcher/data/ConvertedFileDao.kt
+++ b/app/src/main/java/com/neaniesoft/sonicswitcher/data/ConvertedFileDao.kt
@@ -1,0 +1,21 @@
+package com.neaniesoft.sonicswitcher.data
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.Query
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface ConvertedFileDao {
+    @Query("SELECT * FROM converted_files ORDER BY timestampMillis DESC")
+    fun getAllFiles(): Flow<List<ConvertedFileEntity>>
+
+    @Insert
+    suspend fun insertFile(file: ConvertedFileEntity)
+
+    @Query("DELETE FROM converted_files")
+    suspend fun clearAll()
+
+    @Query("SELECT COUNT(*) FROM converted_files")
+    fun getCount(): Flow<Int>
+}

--- a/app/src/main/java/com/neaniesoft/sonicswitcher/data/ConvertedFileEntity.kt
+++ b/app/src/main/java/com/neaniesoft/sonicswitcher/data/ConvertedFileEntity.kt
@@ -1,0 +1,17 @@
+package com.neaniesoft.sonicswitcher.data
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+/**
+ * Represents a converted file in the queue.
+ * The URI is stored as a string to persist across process death.
+ */
+@Entity(tableName = "converted_files")
+data class ConvertedFileEntity(
+    @PrimaryKey(autoGenerate = true)
+    val id: Long = 0,
+    val uri: String,
+    val displayName: String,
+    val timestampMillis: Long,
+)

--- a/app/src/main/java/com/neaniesoft/sonicswitcher/data/ConvertedFileRepository.kt
+++ b/app/src/main/java/com/neaniesoft/sonicswitcher/data/ConvertedFileRepository.kt
@@ -1,0 +1,56 @@
+package com.neaniesoft.sonicswitcher.data
+
+import android.net.Uri
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Repository for managing the queue of converted files.
+ * Provides a clean API for UI layer to interact with persisted queue data.
+ */
+@Singleton
+class ConvertedFileRepository
+    @Inject
+    constructor(
+        private val dao: ConvertedFileDao,
+    ) {
+        /**
+         * Flow of all converted files in the queue, ordered by newest first.
+         */
+        fun getAllFiles(): Flow<List<ConvertedFile>> =
+            dao.getAllFiles().map {
+                    entities ->
+                entities.map { it.toDomainModel() }
+            }
+
+        /**
+         * Flow of the count of files in the queue.
+         */
+        fun getFileCount(): Flow<Int> = dao.getCount()
+
+        /**
+         * Add a file to the queue.
+         */
+        suspend fun addFile(
+            uri: Uri,
+            displayName: String,
+            timestampMillis: Long,
+        ) {
+            dao.insertFile(
+                ConvertedFileEntity(
+                    uri = uri.toString(),
+                    displayName = displayName,
+                    timestampMillis = timestampMillis,
+                ),
+            )
+        }
+
+        /**
+         * Clear all files from the queue.
+         */
+        suspend fun clearAll() {
+            dao.clearAll()
+        }
+    }

--- a/app/src/main/java/com/neaniesoft/sonicswitcher/data/SonicSwitcherDatabase.kt
+++ b/app/src/main/java/com/neaniesoft/sonicswitcher/data/SonicSwitcherDatabase.kt
@@ -1,0 +1,13 @@
+package com.neaniesoft.sonicswitcher.data
+
+import androidx.room.Database
+import androidx.room.RoomDatabase
+
+@Database(
+    entities = [ConvertedFileEntity::class],
+    version = 1,
+    exportSchema = false,
+)
+abstract class SonicSwitcherDatabase : RoomDatabase() {
+    abstract fun convertedFileDao(): ConvertedFileDao
+}

--- a/app/src/main/java/com/neaniesoft/sonicswitcher/di/DatabaseModule.kt
+++ b/app/src/main/java/com/neaniesoft/sonicswitcher/di/DatabaseModule.kt
@@ -1,0 +1,31 @@
+package com.neaniesoft.sonicswitcher.di
+
+import android.content.Context
+import androidx.room.Room
+import com.neaniesoft.sonicswitcher.data.ConvertedFileDao
+import com.neaniesoft.sonicswitcher.data.SonicSwitcherDatabase
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object DatabaseModule {
+    @Provides
+    @Singleton
+    fun provideDatabase(
+        @ApplicationContext context: Context,
+    ): SonicSwitcherDatabase =
+        Room
+            .databaseBuilder(
+                context,
+                SonicSwitcherDatabase::class.java,
+                "sonic_switcher_database",
+            ).build()
+
+    @Provides
+    fun provideConvertedFileDao(database: SonicSwitcherDatabase): ConvertedFileDao = database.convertedFileDao()
+}

--- a/app/src/main/java/com/neaniesoft/sonicswitcher/di/DatabaseModule.kt
+++ b/app/src/main/java/com/neaniesoft/sonicswitcher/di/DatabaseModule.kt
@@ -24,7 +24,9 @@ object DatabaseModule {
                 context,
                 SonicSwitcherDatabase::class.java,
                 "sonic_switcher_database",
-            ).build()
+            )
+            .fallbackToDestructiveMigration(dropAllTables = true)
+            .build()
 
     @Provides
     fun provideConvertedFileDao(database: SonicSwitcherDatabase): ConvertedFileDao = database.convertedFileDao()

--- a/app/src/main/java/com/neaniesoft/sonicswitcher/screens/mainscreen/MainScreen.kt
+++ b/app/src/main/java/com/neaniesoft/sonicswitcher/screens/mainscreen/MainScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -107,12 +108,7 @@ fun MainScreen(
                             type = "audio/mpeg"
                             flags = Intent.FLAG_GRANT_READ_URI_PERMISSION
                         }
-                    context.grantUriPermission(
-                        context.packageName,
-                        event.uri,
-                        Intent.FLAG_GRANT_READ_URI_PERMISSION,
-                    )
-                    context.startActivity(intent)
+                    context.startActivity(Intent.createChooser(intent, null))
                 }
 
                 is OpenShareSheetForMultiple -> {
@@ -122,13 +118,6 @@ fun MainScreen(
                             type = "audio/mpeg"
                             flags = Intent.FLAG_GRANT_READ_URI_PERMISSION
                         }
-                    event.uris.forEach { uri ->
-                        context.grantUriPermission(
-                            context.packageName,
-                            uri,
-                            Intent.FLAG_GRANT_READ_URI_PERMISSION,
-                        )
-                    }
                     context.startActivity(Intent.createChooser(intent, null))
                 }
             }
@@ -322,20 +311,23 @@ fun QueueSection(
                 TextButton(onClick = onShareAllClicked) {
                     Icon(
                         Icons.Default.Share,
-                        contentDescription = null,
+                        contentDescription = stringResource(id = R.string.share_all_content_description),
                         modifier = Modifier.padding(end = 4.dp),
                     )
                     Text(stringResource(id = R.string.share_all_button, queueCount))
                 }
                 IconButton(onClick = onClearQueueClicked) {
-                    Icon(Icons.Default.Delete, contentDescription = stringResource(id = R.string.clear_queue_button))
+                    Icon(
+                        Icons.Default.Delete,
+                        contentDescription = stringResource(id = R.string.clear_queue_content_description),
+                    )
                 }
             }
         }
 
         // Queue list
         LazyColumn(
-            modifier = Modifier.fillMaxWidth(),
+            modifier = Modifier.fillMaxWidth().heightIn(max = 200.dp),
             contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
             verticalArrangement = Arrangement.spacedBy(4.dp),
         ) {
@@ -461,19 +453,19 @@ fun PreviewMainScreenWithQueue() =
                     id = 1,
                     uri = Uri.parse("http://some/url1"),
                     displayName = "converted_file_1.mp3",
-                    timestampMillis = System.currentTimeMillis(),
+                    timestampMillis = 1704067200000L,
                 ),
                 ConvertedFile(
                     id = 2,
                     uri = Uri.parse("http://some/url2"),
                     displayName = "converted_file_2.mp3",
-                    timestampMillis = System.currentTimeMillis(),
+                    timestampMillis = 1704153600000L,
                 ),
                 ConvertedFile(
                     id = 3,
                     uri = Uri.parse("http://some/url3"),
                     displayName = "converted_file_3.mp3",
-                    timestampMillis = System.currentTimeMillis(),
+                    timestampMillis = 1704240000000L,
                 ),
             ),
         queueCount = 3,

--- a/app/src/main/java/com/neaniesoft/sonicswitcher/screens/mainscreen/UiEvents.kt
+++ b/app/src/main/java/com/neaniesoft/sonicswitcher/screens/mainscreen/UiEvents.kt
@@ -9,3 +9,5 @@ object OpenFileChooser : UiEvents()
 data class OpenOutputFileChooser(val defaultFilename: String) : UiEvents()
 
 data class OpenShareSheet(val uri: Uri) : UiEvents()
+
+data class OpenShareSheetForMultiple(val uris: List<Uri>) : UiEvents()

--- a/app/src/main/java/com/neaniesoft/sonicswitcher/screens/mainscreen/usecases/AddFileToQueueUseCase.kt
+++ b/app/src/main/java/com/neaniesoft/sonicswitcher/screens/mainscreen/usecases/AddFileToQueueUseCase.kt
@@ -1,0 +1,23 @@
+package com.neaniesoft.sonicswitcher.screens.mainscreen.usecases
+
+import android.net.Uri
+import com.neaniesoft.sonicswitcher.data.ConvertedFileRepository
+import java.time.Clock
+import javax.inject.Inject
+
+/**
+ * Adds a converted file to the queue with current timestamp.
+ */
+class AddFileToQueueUseCase
+    @Inject
+    constructor(
+        private val repository: ConvertedFileRepository,
+        private val getFileDisplayName: GetFileDisplayNameUseCase,
+        private val clock: Clock,
+    ) {
+        suspend operator fun invoke(uri: Uri) {
+            val displayName = getFileDisplayName(uri)
+            val timestamp = clock.millis()
+            repository.addFile(uri, displayName, timestamp)
+        }
+    }

--- a/app/src/main/java/com/neaniesoft/sonicswitcher/screens/mainscreen/usecases/ClearQueueUseCase.kt
+++ b/app/src/main/java/com/neaniesoft/sonicswitcher/screens/mainscreen/usecases/ClearQueueUseCase.kt
@@ -1,0 +1,17 @@
+package com.neaniesoft.sonicswitcher.screens.mainscreen.usecases
+
+import com.neaniesoft.sonicswitcher.data.ConvertedFileRepository
+import javax.inject.Inject
+
+/**
+ * Clears all files from the queue.
+ */
+class ClearQueueUseCase
+    @Inject
+    constructor(
+        private val repository: ConvertedFileRepository,
+    ) {
+        suspend operator fun invoke() {
+            repository.clearAll()
+        }
+    }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5,4 +5,9 @@
     <string name="share_button">Share file</string>
     <string name="choose_file_button">Choose file</string>
     <string name="convert_button">Convert</string>
+    <string name="add_to_queue_button">Add to queue</string>
+    <string name="share_all_button">Share all (%d)</string>
+    <string name="clear_queue_button">Clear queue</string>
+    <string name="queue_header">Queue (%d files)</string>
+    <string name="queue_empty">No files in queue</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -7,7 +7,9 @@
     <string name="convert_button">Convert</string>
     <string name="add_to_queue_button">Add to queue</string>
     <string name="share_all_button">Share all (%d)</string>
+    <string name="share_all_content_description">Share all queued files</string>
     <string name="clear_queue_button">Clear queue</string>
+    <string name="clear_queue_content_description">Delete all queued files</string>
     <string name="queue_header">Queue (%d files)</string>
     <string name="queue_empty">No files in queue</string>
 </resources>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 android-plugin = "8.13.1"
-kotlin = "2.2.21"
+kotlin = "2.2.10"
 ksp = "2.2.10-2.0.2"
 compile-sdk = "36"
 min-sdk = "29"
@@ -11,7 +11,7 @@ hilt = "2.57.2"
 google-services = "4.4.4"
 firebase-crashlytics = "3.0.6"
 ktlint = "12.1.2"
-room = "2.6.1"
+room = "2.7.0-alpha12"
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "android-plugin" }


### PR DESCRIPTION
## Summary
Add a queue feature for converted files that persists across process death.

> **Note:** This feature was implemented with AI assistance (GitHub Copilot).

## Changes

### Database Layer (Room)
- `ConvertedFileEntity`: Room entity for persisting converted files
- `ConvertedFileDao`: DAO with operations for queue management
- `SonicSwitcherDatabase`: Room database configuration
- `ConvertedFile`: Domain model (separates persistence from business logic)
- `ConvertedFileRepository`: Repository pattern for clean data access
- `DatabaseModule`: Hilt module for DI

### Business Logic
- `AddFileToQueueUseCase`: Adds converted files to queue with timestamp
- `ClearQueueUseCase`: Clears entire queue

### ViewModel
- Added `queuedFiles` and `queueCount` StateFlows
- New actions: `onAddToQueueClicked`, `onShareAllQueuedClicked`, `onClearQueueClicked`

### UI
- "Add to queue" button in Complete state (alongside Share)
- `QueueSection` composable with file list, share all, and clear buttons
- `ACTION_SEND_MULTIPLE` intent handling for sharing multiple files
- Queue section only displays when files exist

### Dependencies
- Upgraded Room from 2.6.1 to 2.7.0-alpha12 (Kotlin 2.2.x compatibility)

## How It Works
1. Convert a file → see "Share" and "Add to queue" buttons
2. Add to queue → file persists in Room DB → queue section appears
3. Share all → opens share sheet with all queued files
4. Clear → removes all files from queue

Queue survives process death via Room database.