### PR TITLE
Add keystore signing configuration for release builds

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,3 +1,6 @@
+import java.io.FileInputStream
+import java.util.Properties
+
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
@@ -6,6 +9,13 @@ plugins {
     alias(libs.plugins.dagger.hilt)
     alias(libs.plugins.google.services)
     alias(libs.plugins.firebase.crashlytics)
+}
+
+// Load keystore properties from local.properties
+val keystorePropertiesFile = rootProject.file("local.properties")
+val keystoreProperties = Properties()
+if (keystorePropertiesFile.exists()) {
+    keystoreProperties.load(FileInputStream(keystorePropertiesFile))
 }
 
 android {
@@ -25,6 +35,18 @@ android {
         }
     }
 
+    signingConfigs {
+        create("release") {
+            val keystorePath = keystoreProperties.getProperty("RELEASE_KEYSTORE_PATH")
+            if (keystorePath != null) {
+                storeFile = file(keystorePath)
+            }
+            storePassword = keystoreProperties.getProperty("RELEASE_KEYSTORE_PASSWORD")
+            keyAlias = keystoreProperties.getProperty("RELEASE_KEY_ALIAS")
+            keyPassword = keystoreProperties.getProperty("RELEASE_KEY_PASSWORD")
+        }
+    }
+
     buildTypes {
         release {
             isMinifyEnabled = true
@@ -32,6 +54,7 @@ android {
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro",
             )
+            signingConfig = signingConfigs.getByName("release")
         }
     }
     compileOptions {

--- a/local.properties.sample
+++ b/local.properties.sample
@@ -1,0 +1,14 @@
+## This file must *NOT* be checked into Version Control Systems,
+# as it contains information specific to your local configuration.
+#
+# Copy this file to local.properties and fill in your actual values
+#
+# Location of the SDK. This is only used by Gradle.
+sdk.dir=/path/to/your/Android/sdk
+
+# Keystore configuration for release builds
+# IMPORTANT: Fill in the passwords below and keep local.properties private!
+RELEASE_KEYSTORE_PATH=/path/to/your/keystore.jks
+RELEASE_KEY_ALIAS=your_key_alias
+RELEASE_KEYSTORE_PASSWORD=your_keystore_password
+RELEASE_KEY_PASSWORD=your_key_password


### PR DESCRIPTION
This PR adds keystore signing configuration to enable signed release builds for Play Store distribution.

## Changes

### Gradle Configuration
- Load keystore properties from `local.properties` (not committed to git)
- Add `signingConfigs.release` with keystore path, alias, and passwords
- Configure `buildTypes.release` to use the signing config

### Files Modified
- **app/build.gradle.kts**: Added imports and signing configuration
- **local.properties.sample**: Template file for developers (safe to commit)

### Configuration Details
- **Keystore Path**: `/Users/micaela/Development/keystores/shiningdawn.jks`
- **Key Alias**: `upload`
- **Passwords**: Must be filled in `local.properties` (not in version control)

### local.properties Format
```properties
RELEASE_KEYSTORE_PATH=/Users/micaela/Development/keystores/shiningdawn.jks
RELEASE_KEY_ALIAS=upload
RELEASE_KEYSTORE_PASSWORD=your_password_here
RELEASE_KEY_PASSWORD=your_password_here
```

## Testing
- ✅ Gradle sync successful
- ⏳ Release build pending (requires passwords to be filled)

## Security Notes
- `local.properties` is already in `.gitignore` and will NOT be committed
- Passwords must be filled locally by the developer
- `local.properties.sample` provides a template without sensitive data

## Next Steps
After filling in passwords in `local.properties`:
```bash
./gradlew assembleRelease
```

The signed APK will be generated at:
`app/build/outputs/apk/release/app-release.apk`