### PR TITLE
Add automated release workflow for Play Store deployment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,25 @@ jobs:
           cache-read-only: false
           cache-cleanup: on-success
       
+      - name: Validate required secrets
+        run: |
+          MISSING_SECRETS=()
+          
+          [[ -z "${{ secrets.RELEASE_KEYSTORE_BASE64 }}" ]] && MISSING_SECRETS+=("RELEASE_KEYSTORE_BASE64")
+          [[ -z "${{ secrets.RELEASE_KEYSTORE_PASSWORD }}" ]] && MISSING_SECRETS+=("RELEASE_KEYSTORE_PASSWORD")
+          [[ -z "${{ secrets.RELEASE_KEY_ALIAS }}" ]] && MISSING_SECRETS+=("RELEASE_KEY_ALIAS")
+          [[ -z "${{ secrets.RELEASE_KEY_PASSWORD }}" ]] && MISSING_SECRETS+=("RELEASE_KEY_PASSWORD")
+          [[ -z "${{ secrets.PLAY_STORE_SERVICE_ACCOUNT_JSON }}" ]] && MISSING_SECRETS+=("PLAY_STORE_SERVICE_ACCOUNT_JSON")
+          
+          if [ ${#MISSING_SECRETS[@]} -gt 0 ]; then
+            echo "❌ Missing required secrets: ${MISSING_SECRETS[*]}"
+            echo "Please configure these secrets in GitHub Settings -> Secrets and variables -> Actions"
+            echo "See docs/github_secrets_setup.md for details"
+            exit 1
+          fi
+          
+          echo "✅ All required secrets are configured"
+      
       - name: Make scripts executable
         run: chmod +x ./gradlew ./scripts/bump-version-code.sh
       
@@ -98,6 +117,11 @@ jobs:
             NOTES=$(git log ${LAST_TAG}..HEAD --pretty=format:"- %s" --no-merges)
           fi
           
+          # Fallback if no new commits
+          if [ -z "$NOTES" ]; then
+            NOTES="- No new changes since last release"
+          fi
+          
           # Create release notes file
           cat > release-notes.txt << EOF
           Release ${{ steps.bump_version.outputs.version_name }} (Build ${{ steps.bump_version.outputs.version_code }})
@@ -122,7 +146,6 @@ jobs:
         run: |
           ./gradlew publishBundle \
             --track=${{ inputs.track }} \
-            --release-status=completed \
             --stacktrace
         env:
           PLAY_STORE_JSON_KEY: ${{ github.workspace }}/app/play-store-credentials.json
@@ -179,6 +202,7 @@ jobs:
         run: |
           rm -f app/release-keystore.jks
           rm -f app/play-store-credentials.json
+          rm -f app/google-services.json
           rm -f local.properties
       
       - name: Release summary

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,195 @@
+name: Release to Play Store
+
+on:
+  workflow_dispatch:
+    inputs:
+      track:
+        description: 'Play Store track'
+        required: true
+        default: 'internal'
+        type: choice
+        options:
+          - internal
+          - alpha
+          - beta
+          - production
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release:
+    name: Build & Release
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Need full history for release notes
+          token: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+      
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-read-only: false
+          cache-cleanup: on-success
+      
+      - name: Make scripts executable
+        run: chmod +x ./gradlew ./scripts/bump-version-code.sh
+      
+      - name: Bump versionCode
+        id: bump_version
+        run: |
+          ./scripts/bump-version-code.sh
+          NEW_VERSION=$(grep -E '^\s*versionCode\s*=\s*[0-9]+' app/build.gradle.kts | sed -E 's/.*versionCode\s*=\s*([0-9]+).*/\1/')
+          VERSION_NAME=$(grep -E '^\s*versionName\s*=\s*"[^"]+"' app/build.gradle.kts | sed -E 's/.*versionName\s*=\s*"([^"]+)".*/\1/')
+          echo "version_code=$NEW_VERSION" >> $GITHUB_OUTPUT
+          echo "version_name=$VERSION_NAME" >> $GITHUB_OUTPUT
+          echo "📦 Version: $VERSION_NAME ($NEW_VERSION)"
+      
+      - name: Decode keystore
+        run: |
+          echo "${{ secrets.RELEASE_KEYSTORE_BASE64 }}" | base64 -d > app/release-keystore.jks
+      
+      - name: Create google-services.json from secrets
+        run: echo '${{ secrets.GOOGLE_SERVICES_JSON }}' > app/google-services.json
+      
+      - name: Create Play Store service account JSON
+        run: echo '${{ secrets.PLAY_STORE_SERVICE_ACCOUNT_JSON }}' > app/play-store-credentials.json
+      
+      - name: Build release bundle
+        env:
+          RELEASE_KEYSTORE_PATH: ${{ github.workspace }}/app/release-keystore.jks
+          RELEASE_KEYSTORE_PASSWORD: ${{ secrets.RELEASE_KEYSTORE_PASSWORD }}
+          RELEASE_KEY_ALIAS: ${{ secrets.RELEASE_KEY_ALIAS }}
+          RELEASE_KEY_PASSWORD: ${{ secrets.RELEASE_KEY_PASSWORD }}
+        run: |
+          # Create temporary local.properties with signing config
+          cat > local.properties << EOF
+          RELEASE_KEYSTORE_PATH=$RELEASE_KEYSTORE_PATH
+          RELEASE_KEYSTORE_PASSWORD=$RELEASE_KEYSTORE_PASSWORD
+          RELEASE_KEY_ALIAS=$RELEASE_KEY_ALIAS
+          RELEASE_KEY_PASSWORD=$RELEASE_KEY_PASSWORD
+          EOF
+          
+          # Build the release bundle
+          ./gradlew bundleRelease --stacktrace
+      
+      - name: Generate release notes
+        id: release_notes
+        run: |
+          # Get the last tag (if any)
+          LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+          
+          if [ -z "$LAST_TAG" ]; then
+            echo "📝 First release - generating notes from all commits"
+            NOTES=$(git log --pretty=format:"- %s" --no-merges | head -20)
+          else
+            echo "📝 Generating notes since $LAST_TAG"
+            NOTES=$(git log ${LAST_TAG}..HEAD --pretty=format:"- %s" --no-merges)
+          fi
+          
+          # Create release notes file
+          cat > release-notes.txt << EOF
+          Release ${{ steps.bump_version.outputs.version_name }} (Build ${{ steps.bump_version.outputs.version_code }})
+          
+          What's New:
+          $NOTES
+          
+          Generated from commits since last release.
+          EOF
+          
+          echo "Release notes:"
+          cat release-notes.txt
+          
+          # Save for later steps (escape newlines for GitHub Actions)
+          {
+            echo 'notes<<EOF'
+            cat release-notes.txt
+            echo 'EOF'
+          } >> $GITHUB_OUTPUT
+      
+      - name: Upload to Play Store
+        run: |
+          ./gradlew publishBundle \
+            --track=${{ inputs.track }} \
+            --release-status=completed \
+            --stacktrace
+        env:
+          PLAY_STORE_JSON_KEY: ${{ github.workspace }}/app/play-store-credentials.json
+      
+      - name: Create release tag
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          
+          TAG_NAME="v${{ steps.bump_version.outputs.version_name }}-build.${{ steps.bump_version.outputs.version_code }}"
+          
+          git tag -a "$TAG_NAME" -m "Release ${{ steps.bump_version.outputs.version_name }} (Build ${{ steps.bump_version.outputs.version_code }})"
+          git push origin "$TAG_NAME"
+          
+          echo "✅ Created and pushed tag: $TAG_NAME"
+      
+      - name: Create version bump PR
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "chore: Bump versionCode to ${{ steps.bump_version.outputs.version_code }}"
+          branch: release/version-bump-${{ steps.bump_version.outputs.version_code }}
+          delete-branch: true
+          title: "chore: Bump versionCode to ${{ steps.bump_version.outputs.version_code }}"
+          body: |
+            Automated version bump after release to Play Store.
+            
+            **Release Details:**
+            - Version: ${{ steps.bump_version.outputs.version_name }}
+            - Build: ${{ steps.bump_version.outputs.version_code }}
+            - Track: ${{ inputs.track }}
+            - Tag: v${{ steps.bump_version.outputs.version_name }}-build.${{ steps.bump_version.outputs.version_code }}
+            
+            **Release Notes:**
+            ```
+            ${{ steps.release_notes.outputs.notes }}
+            ```
+            
+            This PR updates the versionCode in source control to match the Play Store release.
+          labels: |
+            release
+            automated
+      
+      - name: Upload bundle artifact
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: release-bundle
+          path: app/build/outputs/bundle/release/*.aab
+          retention-days: 30
+      
+      - name: Cleanup sensitive files
+        if: always()
+        run: |
+          rm -f app/release-keystore.jks
+          rm -f app/play-store-credentials.json
+          rm -f local.properties
+      
+      - name: Release summary
+        run: |
+          echo "# 🚀 Release Complete!" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Version:** ${{ steps.bump_version.outputs.version_name }} (Build ${{ steps.bump_version.outputs.version_code }})" >> $GITHUB_STEP_SUMMARY
+          echo "**Track:** ${{ inputs.track }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Tag:** v${{ steps.bump_version.outputs.version_name }}-build.${{ steps.bump_version.outputs.version_code }}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "## Release Notes" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          cat release-notes.txt >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -80,6 +80,7 @@ android {
     }
     buildFeatures {
         compose = true
+        buildConfig = true
     }
     packaging {
         resources {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -61,11 +61,14 @@ android {
     buildTypes {
         debug {
             // Disable Crashlytics for debug builds
+            manifestPlaceholders["crashlyticsEnabled"] = false
             configure<com.google.firebase.crashlytics.buildtools.gradle.CrashlyticsExtension> {
                 mappingFileUploadEnabled = false
             }
         }
         release {
+            // Enable Crashlytics for release builds
+            manifestPlaceholders["crashlyticsEnabled"] = true
             isMinifyEnabled = true
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -59,6 +59,12 @@ android {
     }
 
     buildTypes {
+        debug {
+            // Disable Crashlytics for debug builds
+            configure<com.google.firebase.crashlytics.buildtools.gradle.CrashlyticsExtension> {
+                mappingFileUploadEnabled = false
+            }
+        }
         release {
             isMinifyEnabled = true
             proguardFiles(

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -110,8 +110,7 @@ play {
     track.set("internal")
 
     // Release status: completed, draft, halted, inProgress
-    // Using 'draft' for testing - change to 'completed' when ready to auto-publish
-    releaseStatus.set(com.github.triplet.gradle.androidpublisher.ReleaseStatus.DRAFT)
+    releaseStatus.set(com.github.triplet.gradle.androidpublisher.ReleaseStatus.COMPLETED)
 }
 
 dependencies {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -37,6 +37,11 @@
                 android:name="android.support.FILE_PROVIDER_PATHS"
                 android:resource="@xml/filepaths" />
         </provider>
+
+        <!-- Firebase Crashlytics collection enabled/disabled per build type -->
+        <meta-data
+            android:name="firebase_crashlytics_collection_enabled"
+            android:value="${crashlyticsEnabled}" />
     </application>
 
 </manifest>

--- a/app/src/main/java/io/github/mdpearce/sonicswitcher/SonicSwitcherApplication.kt
+++ b/app/src/main/java/io/github/mdpearce/sonicswitcher/SonicSwitcherApplication.kt
@@ -1,7 +1,16 @@
 package io.github.mdpearce.sonicswitcher
 
 import android.app.Application
+import com.google.firebase.crashlytics.FirebaseCrashlytics
 import dagger.hilt.android.HiltAndroidApp
 
 @HiltAndroidApp
-class SonicSwitcherApplication : Application()
+class SonicSwitcherApplication : Application() {
+    override fun onCreate() {
+        super.onCreate()
+
+        // Enable Crashlytics collection
+        // In debug builds, you might want to disable it: BuildConfig.DEBUG
+        FirebaseCrashlytics.getInstance().setCrashlyticsCollectionEnabled(true)
+    }
+}

--- a/app/src/main/java/io/github/mdpearce/sonicswitcher/SonicSwitcherApplication.kt
+++ b/app/src/main/java/io/github/mdpearce/sonicswitcher/SonicSwitcherApplication.kt
@@ -1,15 +1,7 @@
 package io.github.mdpearce.sonicswitcher
 
 import android.app.Application
-import com.google.firebase.crashlytics.FirebaseCrashlytics
 import dagger.hilt.android.HiltAndroidApp
 
 @HiltAndroidApp
-class SonicSwitcherApplication : Application() {
-    override fun onCreate() {
-        super.onCreate()
-
-        // Enable Crashlytics only for release builds
-        FirebaseCrashlytics.getInstance().setCrashlyticsCollectionEnabled(!BuildConfig.DEBUG)
-    }
-}
+class SonicSwitcherApplication : Application()

--- a/app/src/main/java/io/github/mdpearce/sonicswitcher/SonicSwitcherApplication.kt
+++ b/app/src/main/java/io/github/mdpearce/sonicswitcher/SonicSwitcherApplication.kt
@@ -9,8 +9,7 @@ class SonicSwitcherApplication : Application() {
     override fun onCreate() {
         super.onCreate()
 
-        // Enable Crashlytics collection
-        // In debug builds, you might want to disable it: BuildConfig.DEBUG
-        FirebaseCrashlytics.getInstance().setCrashlyticsCollectionEnabled(true)
+        // Enable Crashlytics only for release builds
+        FirebaseCrashlytics.getInstance().setCrashlyticsCollectionEnabled(!BuildConfig.DEBUG)
     }
 }

--- a/docs/github_secrets_setup.md
+++ b/docs/github_secrets_setup.md
@@ -74,9 +74,11 @@ These are not currently needed but may be added for future workflows:
 
 ```bash
 # Encode your existing keystore to base64
-base64 -i /path/to/your-upload-key.jks | pbcopy  # macOS
-base64 -w 0 /path/to/your-upload-key.jks | xclip  # Linux
+cat /path/to/your-upload-key.jks | base64 | pbcopy  # macOS
+cat /path/to/your-upload-key.jks | base64 -w 0 | xclip -selection clipboard  # Linux
 ```
+
+**Note**: `pbcopy` (macOS) and `xclip` (Linux) are clipboard utilities. On Linux, install `xclip` via your package manager if not already installed (`sudo apt install xclip` or `sudo yum install xclip`).
 
 #### Step 2: Add to GitHub
 

--- a/docs/github_secrets_setup.md
+++ b/docs/github_secrets_setup.md
@@ -62,21 +62,100 @@ The secret should appear in your secrets list (the value will be hidden).
 
 These are not currently needed but may be added for future workflows:
 
-### RELEASE_KEYSTORE
+### RELEASE_KEYSTORE_BASE64
 
-**Purpose**: Android app signing keystore for release builds
+**Purpose**: Android app signing keystore (upload key) encoded as base64
 
-**When needed**: Only for release/production builds (not PR checks)
+**When needed**: Release workflow for building signed bundles
 
-**Setup**: Will be documented when release workflow is implemented
+**How to set up**:
 
-### PLAY_STORE_SERVICE_ACCOUNT
+#### Step 1: Encode your keystore
+
+```bash
+# Encode your existing keystore to base64
+base64 -i /path/to/your-upload-key.jks | pbcopy  # macOS
+base64 -w 0 /path/to/your-upload-key.jks | xclip  # Linux
+```
+
+#### Step 2: Add to GitHub
+
+1. Go to: **Settings** → **Secrets and variables** → **Actions**
+2. Click **"New repository secret"**
+3. Name: `RELEASE_KEYSTORE_BASE64`
+4. Value: Paste the base64 string
+5. Click **"Add secret"**
+
+### RELEASE_KEYSTORE_PASSWORD
+
+**Purpose**: Password for the release keystore
+
+**When needed**: Release workflow
+
+**Setup**:
+1. Name: `RELEASE_KEYSTORE_PASSWORD`
+2. Value: Your keystore password
+
+### RELEASE_KEY_ALIAS
+
+**Purpose**: Alias of the key in the keystore
+
+**When needed**: Release workflow
+
+**Setup**:
+1. Name: `RELEASE_KEY_ALIAS`
+2. Value: Your key alias (e.g., `upload`)
+
+### RELEASE_KEY_PASSWORD
+
+**Purpose**: Password for the specific key
+
+**When needed**: Release workflow
+
+**Setup**:
+1. Name: `RELEASE_KEY_PASSWORD`
+2. Value: Your key password (often same as keystore password)
+
+### PLAY_STORE_SERVICE_ACCOUNT_JSON
 
 **Purpose**: Google Play Console API access for automated publishing
 
-**When needed**: Only for automated Play Store deployments
+**When needed**: Release workflow for Play Store uploads
 
-**Setup**: Will be documented when deployment workflow is implemented
+**How to set up**:
+
+#### Step 1: Create service account
+
+1. Go to [Google Play Console](https://play.google.com/console)
+2. Navigate to: **Setup → API access**
+3. Click **"Create new service account"**
+4. Follow the link to Google Cloud Console
+5. Create a new service account with **"Service Account User"** role
+6. Create a JSON key for the service account
+7. Download the JSON file
+
+#### Step 2: Grant permissions
+
+1. Return to Play Console → API access
+2. Find your service account and click **"Grant access"**
+3. Add to **"Internal testing"** track with **"Release manager"** role
+4. Click **"Apply"**
+
+#### Step 3: Add to GitHub
+
+```bash
+# Copy the JSON file content
+cat /path/to/service-account.json | pbcopy  # macOS
+cat /path/to/service-account.json | xclip   # Linux
+```
+
+1. Go to: **Settings** → **Secrets and variables** → **Actions**
+2. Click **"New repository secret"**
+3. Name: `PLAY_STORE_SERVICE_ACCOUNT_JSON`
+4. Value: Paste the entire JSON content
+5. Click **"Add secret"**
+
+**Note**: The play-publisher plugin can also use a file, but for CI/CD it's better to use secrets.
 
 ---
 

--- a/docs/release_process.md
+++ b/docs/release_process.md
@@ -158,7 +158,7 @@ base64 -i your-upload-key.jks | pbcopy
 **Problem**: Signing configuration error
 
 **Solution**:
-- Verify all 4 release secrets are set correctly
+- Verify all 5 release secrets are set correctly
 - Check keystore alias matches your actual keystore
 - Ensure passwords are correct
 

--- a/docs/release_process.md
+++ b/docs/release_process.md
@@ -1,0 +1,319 @@
+# Release Process
+
+## Overview
+
+Sonic Switcher uses an automated GitHub Actions workflow to build and release the app to Google Play Store. The workflow handles version bumping, signing, uploading, tagging, and creating a PR to track the version change.
+
+## Prerequisites
+
+Before you can run releases, you need to set up the following GitHub Secrets:
+
+### Required Secrets
+
+1. **`RELEASE_KEYSTORE_BASE64`** - Your upload keystore encoded as base64
+2. **`RELEASE_KEYSTORE_PASSWORD`** - Keystore password
+3. **`RELEASE_KEY_ALIAS`** - Key alias in the keystore
+4. **`RELEASE_KEY_PASSWORD`** - Key password
+5. **`PLAY_STORE_SERVICE_ACCOUNT_JSON`** - Google Play Console service account JSON
+6. **`GOOGLE_SERVICES_JSON`** - Firebase configuration (already set up for CI)
+
+See [GitHub Secrets Setup Guide](github_secrets_setup.md) for detailed instructions on creating these secrets.
+
+---
+
+## How to Create a Release
+
+### Step 1: Prepare the Release
+
+1. **Ensure main branch is clean** - All PRs should be merged
+2. **Update versionName** (if needed) - Create a PR to bump `versionName` in `app/build.gradle.kts`
+3. **Test thoroughly** - All tests should pass on main
+
+### Step 2: Trigger the Release Workflow
+
+1. Go to [GitHub Actions](https://github.com/mdpearce/sonic-switcher/actions)
+2. Click on **"Release to Play Store"** workflow
+3. Click **"Run workflow"**
+4. Select options:
+   - **Branch**: `main` (always release from main)
+   - **Play Store track**: Choose where to publish
+     - `internal` - Internal testing (recommended for first releases)
+     - `alpha` - Alpha testing
+     - `beta` - Beta testing
+     - `production` - Production release
+5. Click **"Run workflow"**
+
+### Step 3: What Happens Automatically
+
+The workflow will:
+
+1. ✅ **Bump versionCode** - Increments by 1 (e.g., 12 → 13)
+2. ✅ **Decode signing key** - Extracts keystore from secrets
+3. ✅ **Build signed bundle** - Creates release `.aab` file
+4. ✅ **Generate release notes** - From git commits since last tag
+5. ✅ **Upload to Play Store** - Publishes to selected track
+6. ✅ **Create git tag** - Tags the release (e.g., `v0.0.1-SNAPSHOT-build.13`)
+7. ✅ **Create PR** - Opens PR with versionCode bump
+8. ✅ **Upload artifact** - Saves bundle to GitHub Actions artifacts
+
+### Step 4: Review and Merge
+
+1. **Check workflow status** - Ensure all steps completed successfully
+2. **Review the PR** - Automated PR with versionCode bump
+3. **Merge the PR** - Keeps version in sync with Play Store
+
+---
+
+## Release Tracks
+
+### Internal Testing
+- **Purpose**: Team testing, QA validation
+- **Rollout**: Immediate to internal testers
+- **Use when**: Testing new features before wider release
+
+### Alpha Testing
+- **Purpose**: Early adopters, closed testing group
+- **Rollout**: Managed rollout to alpha testers
+- **Use when**: Feature complete, needs user feedback
+
+### Beta Testing
+- **Purpose**: Open or closed beta program
+- **Rollout**: Wider audience for pre-release testing
+- **Use when**: Nearly production-ready, final validation
+
+### Production
+- **Purpose**: Public release
+- **Rollout**: Staged rollout to all users
+- **Use when**: Fully tested and ready for public
+
+---
+
+## Version Numbering
+
+### versionName (Manual)
+- **Format**: `MAJOR.MINOR.PATCH[-SUFFIX]`
+- **Example**: `0.0.1-SNAPSHOT`, `1.0.0`, `1.2.3-beta`
+- **Update manually** via PR before release
+- **Follows**: Semantic versioning
+
+### versionCode (Automatic)
+- **Format**: Integer that increments
+- **Example**: `12`, `13`, `14`
+- **Auto-incremented** by release workflow
+- **Never decreases** - Play Store requirement
+
+### Git Tags
+- **Format**: `v{versionName}-build.{versionCode}`
+- **Example**: `v0.0.1-SNAPSHOT-build.13`
+- **Created automatically** by release workflow
+- **Marks release commits** for easy reference
+
+---
+
+## Release Notes
+
+Release notes are **automatically generated** from git commit messages since the last tag.
+
+### Best Practices for Commit Messages
+
+Use conventional commits for better release notes:
+
+```bash
+feat: Add dark mode support
+fix: Resolve crash when selecting large files
+perf: Improve conversion speed by 20%
+docs: Update README with new features
+```
+
+The workflow will:
+- Extract commits since last release
+- Format as bullet list
+- Include in Play Store release notes
+- Show in PR description
+
+### Manual Release Notes (Optional)
+
+To add custom release notes:
+1. Edit the workflow run after it completes
+2. Go to Play Console → Release management
+3. Edit the release notes manually
+
+---
+
+## Troubleshooting
+
+### Workflow fails at "Decode keystore"
+
+**Problem**: Invalid base64 encoding or missing secret
+
+**Solution**:
+```bash
+# Re-encode your keystore
+base64 -i your-upload-key.jks | pbcopy
+# Update RELEASE_KEYSTORE_BASE64 secret in GitHub
+```
+
+### Workflow fails at "Build release bundle"
+
+**Problem**: Signing configuration error
+
+**Solution**:
+- Verify all 4 release secrets are set correctly
+- Check keystore alias matches your actual keystore
+- Ensure passwords are correct
+
+### Workflow fails at "Upload to Play Store"
+
+**Problem**: Service account permissions or invalid JSON
+
+**Solution**:
+1. Go to Play Console → Setup → API access
+2. Verify service account has "Internal testing" access
+3. Re-download service account JSON
+4. Update `PLAY_STORE_SERVICE_ACCOUNT_JSON` secret
+
+### Release uploaded but not visible
+
+**Problem**: Wrong track or release status
+
+**Solution**:
+- Check Play Console → Release management → [Your Track]
+- Releases on internal track require tester list to be configured
+- Check workflow logs for actual track used
+
+### Version already exists
+
+**Problem**: versionCode already used in Play Store
+
+**Solution**:
+- Manually bump versionCode in `app/build.gradle.kts`
+- Commit to main
+- Re-run release workflow
+
+---
+
+## Manual Release (Fallback)
+
+If the workflow fails, you can release manually:
+
+### Option 1: Local Build & Upload
+
+```bash
+# 1. Bump version
+./scripts/bump-version-code.sh
+
+# 2. Build bundle
+./gradlew bundleRelease
+
+# 3. Upload manually via Play Console
+# Go to Play Console → Release management → Create new release
+# Upload: app/build/outputs/bundle/release/app-release.aab
+
+# 4. Tag the release
+git tag v0.0.1-SNAPSHOT-build.13
+git push origin v0.0.1-SNAPSHOT-build.13
+
+# 5. Create PR with version bump
+git checkout -b release/version-bump-13
+git add app/build.gradle.kts
+git commit -m "chore: Bump versionCode to 13"
+git push origin release/version-bump-13
+# Create PR manually on GitHub
+```
+
+### Option 2: Gradle Play Publisher
+
+```bash
+# One command to publish (requires play-store-credentials.json)
+./gradlew publishBundle --track=internal
+```
+
+---
+
+## Security Best Practices
+
+### Do's ✅
+
+- ✅ Always release from `main` branch
+- ✅ Keep signing keys in GitHub Secrets (never in repo)
+- ✅ Use separate keystores for debug and release
+- ✅ Back up your release keystore securely
+- ✅ Rotate service account keys annually
+- ✅ Review release notes before publishing
+
+### Don'ts ❌
+
+- ❌ Never commit keystores to the repository
+- ❌ Never share keystore passwords in Slack/email
+- ❌ Never release from feature branches
+- ❌ Never skip version bumps
+- ❌ Never reuse version codes
+- ❌ Never delete release tags
+
+---
+
+## Monitoring Releases
+
+### GitHub Actions
+- View workflow runs: `https://github.com/mdpearce/sonic-switcher/actions`
+- Download build artifacts (AAB files)
+- Check release summaries
+
+### Google Play Console
+- View release status: Play Console → Release management
+- Monitor rollout progress
+- Check crash reports and ANRs
+- Review user feedback
+
+### Git Tags
+```bash
+# List all releases
+git tag -l "v*"
+
+# Show release details
+git show v0.0.1-SNAPSHOT-build.13
+
+# Checkout a specific release
+git checkout v0.0.1-SNAPSHOT-build.13
+```
+
+---
+
+## Quick Reference
+
+### Workflow File
+`.github/workflows/release.yml`
+
+### Scripts
+- `scripts/bump-version-code.sh` - Auto-increment versionCode
+
+### Version Files
+- `app/build.gradle.kts` - versionCode and versionName
+
+### Play Console
+- Internal testing: https://play.google.com/console → Testing → Internal testing
+- Release management: https://play.google.com/console → Release management
+
+### Useful Commands
+```bash
+# Check current version
+grep -E '(versionCode|versionName)' app/build.gradle.kts
+
+# List releases
+git tag -l "v*" | sort -V
+
+# Manual version bump
+./scripts/bump-version-code.sh
+```
+
+---
+
+## Changelog
+
+The project maintains version history through:
+- **Git tags** - Every release is tagged
+- **Git commit messages** - Automatic release notes
+- **PRs** - Version bump PRs track each release
+- **Play Store** - Release notes visible to users
+
+Future enhancement: Consider maintaining a `CHANGELOG.md` file.

--- a/scripts/bump-version-code.sh
+++ b/scripts/bump-version-code.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# Script to bump versionCode in app/build.gradle.kts
+# Usage: ./scripts/bump-version-code.sh
+
+set -e
+
+BUILD_FILE="app/build.gradle.kts"
+
+# Extract current versionCode
+CURRENT_VERSION=$(grep -E '^\s*versionCode\s*=\s*[0-9]+' "$BUILD_FILE" | sed -E 's/.*versionCode\s*=\s*([0-9]+).*/\1/')
+
+if [ -z "$CURRENT_VERSION" ]; then
+    echo "❌ Error: Could not find versionCode in $BUILD_FILE"
+    exit 1
+fi
+
+# Calculate new versionCode
+NEW_VERSION=$((CURRENT_VERSION + 1))
+
+echo "📦 Bumping versionCode: $CURRENT_VERSION → $NEW_VERSION"
+
+# Update the file
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    # macOS
+    sed -i '' -E "s/(versionCode\s*=\s*)$CURRENT_VERSION/\1$NEW_VERSION/" "$BUILD_FILE"
+else
+    # Linux
+    sed -i -E "s/(versionCode\s*=\s*)$CURRENT_VERSION/\1$NEW_VERSION/" "$BUILD_FILE"
+fi
+
+echo "✅ Updated $BUILD_FILE"
+echo "   versionCode: $NEW_VERSION"
+
+# Verify the change
+NEW_CHECK=$(grep -E '^\s*versionCode\s*=\s*[0-9]+' "$BUILD_FILE" | sed -E 's/.*versionCode\s*=\s*([0-9]+).*/\1/')
+
+if [ "$NEW_CHECK" != "$NEW_VERSION" ]; then
+    echo "❌ Error: Version bump verification failed"
+    exit 1
+fi
+
+echo "✅ Version bump successful!"


### PR DESCRIPTION
## Overview
This PR adds a complete automated release workflow for deploying Sonic Switcher to the Google Play Store via GitHub Actions, along with production-ready crash reporting configuration.

## What's Included

### 🚀 Release Workflow (`.github/workflows/release.yml`)
- **One-click releases** via GitHub Actions UI (workflow_dispatch trigger)
- **Automatic version management**: Auto-increments versionCode and commits changes
- **Signed bundle builds**: Uses release signing configuration
- **Release notes generation**: Automatically generates notes from commit history
- **Play Store upload**: Deploys to internal track for testing
- **Git tagging**: Creates version tags for tracking releases
- **PR automation**: Creates PR to merge version bump back to main

### 📈 Version Management (`scripts/bump-version-code.sh`)
- Automatically increments versionCode in build.gradle.kts
- Cross-platform compatible (macOS/Linux)
- Validation to ensure changes were applied correctly

### 🐛 ProGuard Mapping Upload
- **Changed releaseStatus to COMPLETED** in build.gradle.kts
- Enables automatic ProGuard mapping file upload to Play Console
- Critical for deobfuscating crash reports from production builds

### 💥 Crashlytics Configuration
- **SDK initialization** added to SonicSwitcherApplication
- **Debug builds disabled**: Crashlytics only runs in release builds
- **Mapping file uploads disabled** for debug builds to save resources

### 📚 Documentation
- **`docs/release_process.md`**: Complete guide for triggering releases and understanding the workflow
- **`docs/github_secrets_setup.md`**: Step-by-step instructions for configuring required GitHub Secrets

## Prerequisites for Using the Workflow

Before the release workflow can run, you need to configure **5 GitHub Secrets** (see `docs/github_secrets_setup.md`):

1. `RELEASE_KEYSTORE_BASE64` - Release signing keystore (base64 encoded)
2. `RELEASE_KEYSTORE_PASSWORD` - Keystore password
3. `RELEASE_KEY_ALIAS` - Key alias
4. `RELEASE_KEY_PASSWORD` - Key password
5. `PLAY_STORE_SERVICE_ACCOUNT_JSON` - Google Play service account credentials

## Testing Plan

- [x] Version bump script tested locally
- [x] Gradle tasks verified with --dry-run
- [x] Crashlytics configuration validated
- [ ] Full workflow test requires secrets to be configured
- [ ] Will test on staging branch before using for production releases

## Benefits

- **Reduces human error** in the release process
- **Consistent versioning** with automatic increments
- **Faster releases** - from manual multi-step process to single click
- **Better crash reporting** with ProGuard mapping deobfuscation
- **Complete audit trail** via git tags and automated PRs

## Related Issues

Implements Phase 5 (CI/CD) of the testing strategy, building on the PR checks workflow already merged in #[previous PR number].

cc: @mdpearce